### PR TITLE
Check current shift for overlap with saved shifts

### DIFF
--- a/Gordon360/ApiControllers/JobsController.cs
+++ b/Gordon360/ApiControllers/JobsController.cs
@@ -188,5 +188,27 @@ namespace Gordon360.ApiControllers
             }
             return Ok(result);
         }
+
+        /// <summary>
+        /// Check for shift overlapping with entered time
+        /// </summary>
+        [HttpPost]
+        [Route("overlapShiftCheck")]
+        public IHttpActionResult checkForOverlap([FromBody] ShiftViewModel shiftDetails)
+        {
+            IEnumerable<OverlappingShiftIdViewModel> result = null;
+            try
+            {
+                System.Diagnostics.Debug.WriteLine("Checking for overlapping shifts");
+                result = _jobsService.checkForOverlappingShift(shiftDetails.ID_NUM, shiftDetails.SHIFT_START_DATETIME, shiftDetails.SHIFT_END_DATETIME);
+            }
+            catch(Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e.Message);
+                return InternalServerError();
+            }
+
+            return Ok(result);
+        }
     }
 }

--- a/Gordon360/Documentation/Gordon360.xml
+++ b/Gordon360/Documentation/Gordon360.xml
@@ -216,6 +216,45 @@
             </summary>
             <returns>The result of deleting the shift</returns>
         </member>
+        <member name="M:Gordon360.ApiControllers.JobsController.checkForOverlap(Gordon360.Models.ViewModels.ShiftViewModel)">
+            <summary>
+            Check for shift overlapping with entered time
+            </summary>
+        </member>
+        <member name="M:Gordon360.ApiControllers.SaveController.GetUpcomingRides">
+            <summary>
+             Gets all upcoming ride objects
+            </summary>
+            <returns>A IEnumerable of rides objects</returns>
+        </member>
+        <member name="M:Gordon360.ApiControllers.SaveController.GetUpcomingRidesForUser">
+            <summary>
+             Gets all upcoming ride objects for a user
+            </summary>
+            <returns>A IEnumerable of rides objects</returns>
+        </member>
+        <member name="M:Gordon360.ApiControllers.SaveController.PostRide(Gordon360.Models.Save_Rides)">
+            <summary>
+             Create new ride object for a user
+            </summary>
+            <returns>Successfully posted ride object</returns>
+        </member>
+        <member name="M:Gordon360.ApiControllers.SaveController.DeleteRide(System.String)">
+            <summary>Delete an existing ride item</summary>
+            <param name="rideID">The identifier for the ride to be deleted</param>
+            <remarks>Calls the server to make a call and remove the given ride from the database</remarks>
+        </member>
+        <member name="M:Gordon360.ApiControllers.SaveController.PostBooking(Gordon360.Models.Save_Bookings)">
+            <summary>
+             Create new booking object for a user
+            </summary>
+            <returns>Successfully posted booking object</returns>
+        </member>
+        <member name="M:Gordon360.ApiControllers.SaveController.DeleteBooking(System.String)">
+            <summary>Delete an existing booking item</summary>
+            <param name="rideID">The identifier for the booking to be deleted</param>
+            <remarks>Calls the server to make a call and remove the given booking from the database</remarks>
+        </member>
         <member name="M:Gordon360.Controllers.Api.ContentManagementController.GetSliderContent">
             <summary>Get all the slider content for the dashboard slider</summary>
             <returns>A list of all the slides for the slider</returns>

--- a/Gordon360/Gordon360.csproj
+++ b/Gordon360/Gordon360.csproj
@@ -439,6 +439,7 @@
     </Compile>
     <Compile Include="Models\ViewModels\ActiveJobSelectionParametersModel.cs" />
     <Compile Include="Models\ViewModels\ActiveJobViewModel.cs" />
+    <Compile Include="Models\ViewModels\OverlappingShiftIdViewModel.cs" />
     <Compile Include="Models\ViewModels\ShiftToDeleteViewModel.cs" />
     <Compile Include="Models\ViewModels\ShiftToSubmitViewModel.cs" />
     <Compile Include="Models\ViewModels\ShiftViewModel.cs" />

--- a/Gordon360/Models/ViewModels/OverlappingShiftIdViewModel.cs
+++ b/Gordon360/Models/ViewModels/OverlappingShiftIdViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Gordon360.Models.ViewModels
+{
+    public class OverlappingShiftIdViewModel
+    {
+        public int ID { get; set; }
+    }
+}

--- a/Gordon360/Services/JobsService.cs
+++ b/Gordon360/Services/JobsService.cs
@@ -135,5 +135,25 @@ namespace Gordon360.Services
 
             return result;
         }
+
+        public IEnumerable<OverlappingShiftIdViewModel> checkForOverlappingShift(int studentID, DateTime shiftStart, DateTime shiftEnd)
+        {
+            IEnumerable<OverlappingShiftIdViewModel> result = null;
+
+            var id_num = new SqlParameter("@ID_NUM", studentID);
+            var start_datetime = new SqlParameter("@start_datetime", shiftStart);
+            var end_datetime = new SqlParameter("@end_datetime", shiftEnd);
+
+            try
+            {
+                result = RawSqlQuery<OverlappingShiftIdViewModel>.StudentTimesheetQuery("student_timesheets_already_worked_these_hours @ID_NUM, @start_datetime, @end_datetime", id_num, start_datetime, end_datetime);
+            }
+            catch(Exception e)
+            {
+                Debug.WriteLine(e.Message);
+            }
+
+            return result;
+        }
     }
 }

--- a/Gordon360/Services/ServiceInterfaces.cs
+++ b/Gordon360/Services/ServiceInterfaces.cs
@@ -154,6 +154,7 @@ namespace Gordon360.Services
         IEnumerable<StudentTimesheetsViewModel> submitShiftForUser(int studentID, int jobID, DateTime shiftEnd, int submittedTo, string lastChangedBy);
         IEnumerable<SupervisorViewModel> getsupervisorNameForJob(int supervisorID);
         IEnumerable<ActiveJobViewModel> getActiveJobs(DateTime shiftStart, DateTime shiftEnd, int studentID);
+        IEnumerable<OverlappingShiftIdViewModel> checkForOverlappingShift(int studentID, DateTime shiftStart, DateTime shiftEnd);
     }
 
     public interface IParticipationService


### PR DESCRIPTION
When a user enters a time in/out on the front end, the API will receive those times and check against the timesheets database to ensure that there is no overlap with any saved shift.