### PR TITLE
Disallow non-ssl connections in release environment

### DIFF
--- a/Gordon360/Startup.cs
+++ b/Gordon360/Startup.cs
@@ -41,9 +41,9 @@ namespace Gordon360
                 AccessTokenExpireTimeSpan = TimeSpan.FromDays(365),
                 Provider = new TokenIssuer(),
                 AccessTokenFormat = new CustomJWTFormat(issuer),
-// #if DEBUG
+ #if DEBUG
                 AllowInsecureHttp = true
-// #endif
+ #endif
 
             });
 


### PR DESCRIPTION
This is an important thing that was forgotten at some point in the past. We can't allow non-SSL connections at all outside of the debug environment.